### PR TITLE
Tweak layout mapping menu

### DIFF
--- a/bundles/LayoutsAdminBundle/Resources/sass/_rules.scss
+++ b/bundles/LayoutsAdminBundle/Resources/sass/_rules.scss
@@ -495,7 +495,7 @@
         padding-right: 0;
     }
 
-    .rule-link-layout {
+    .rule-padded-left {
         display: flex;
         padding: 10px 20px;
         font-size: 12px;

--- a/bundles/LayoutsAdminBundle/Resources/views/admin/layout_resolver/rule.html.twig
+++ b/bundles/LayoutsAdminBundle/Resources/views/admin/layout_resolver/rule.html.twig
@@ -92,12 +92,6 @@
                 </div>
             {% endif %}
 
-            {% if can_edit and rule.layout is not empty %}
-                <div class="nl-rule-cell rule-unlink-layout">
-                    <a href="#" class="js-rule-unlink">{{ 'layout_resolver.rule.unlink_layout'|trans }}</a>
-                </div>
-            {% endif %}
-
             <div class="nl-rule-cell rule-details">
                 <a href="#" class="js-toggle-body">{{ 'layout_resolver.rule.details'|trans }}</a>
             </div>
@@ -122,6 +116,10 @@
 
                     {% if can_delete %}
                         <li><a href="#" class="js-rule-delete">{{ 'layout_resolver.rule.delete_rule'|trans }}</a></li>
+                    {% endif %}
+
+                    {% if can_edit and rule.layout is not empty %}
+                        <li><a href="#" class="js-rule-unlink">{{ 'layout_resolver.rule.unlink_layout'|trans }}</a></li>
                     {% endif %}
 
                     {% if rule.layout is empty or not rule.layout.published or is_granted('nglayouts:layout:clear_cache', rule.layout) %}

--- a/bundles/LayoutsAdminBundle/Resources/views/admin/layout_resolver/rule.html.twig
+++ b/bundles/LayoutsAdminBundle/Resources/views/admin/layout_resolver/rule.html.twig
@@ -81,13 +81,13 @@
 
         <div class="hover-actions">
             {% if rule.layout is not empty and is_granted('nglayouts:layout:edit', rule.layout) %}
-                <div class="nl-rule-cell rule-edit-layout">
+                <div class="nl-rule-cell rule-edit-layout rule-padded-left">
                     <a href="{{ macros.layout_path(rule.layout.id.toString) }}" class="js-open-ngl">{{ 'layout_resolver.rule.edit_layout'|trans }}</a>
                 </div>
             {% endif %}
 
             {% if can_edit %}
-                <div class="nl-rule-cell rule-link-layout">
+                <div class="nl-rule-cell rule-link-layout {% if rule.layout is empty %}rule-padded-left{% endif %}">
                     <a class="js-link-layout" {% if rule.layout is not empty %}data-linked-layout="{{ rule.layout.id.toString }}"{% endif %} data-browser-item-type="layout" href="#">
                         {% if rule.layout is not empty %}
                             {{ 'layout_resolver.rule.link_other_layout'|trans }}

--- a/bundles/LayoutsAdminBundle/Resources/views/admin/layout_resolver/rule.html.twig
+++ b/bundles/LayoutsAdminBundle/Resources/views/admin/layout_resolver/rule.html.twig
@@ -80,6 +80,12 @@
         </div>
 
         <div class="hover-actions">
+            {% if rule.layout is not empty and is_granted('nglayouts:layout:edit', rule.layout) %}
+                <div class="nl-rule-cell rule-edit-layout">
+                    <a href="{{ macros.layout_path(rule.layout.id.toString) }}" class="js-open-ngl">{{ 'layout_resolver.rule.edit_layout'|trans }}</a>
+                </div>
+            {% endif %}
+
             {% if can_edit %}
                 <div class="nl-rule-cell rule-link-layout">
                     <a class="js-link-layout" {% if rule.layout is not empty %}data-linked-layout="{{ rule.layout.id.toString }}"{% endif %} data-browser-item-type="layout" href="#">


### PR DESCRIPTION
On the layout mappings screen, the options for working with layout mappings were tweaked:
* The _Unlink layout_ option was moved into the dropdown menu.
* An _Edit layout_ option was added to allow users to get to the layout editor more quickly.

----

Before:
![image](https://user-images.githubusercontent.com/14966412/179202492-8c1c0f23-1631-41ab-a4a9-aa34f1e5d6fd.png)

After:
![image](https://user-images.githubusercontent.com/14966412/179201942-e12b1be7-3ee2-466d-8912-99c2c7a9c3f3.png)
