### PR TITLE
Fix event being dispatched twice when canceling modal

### DIFF
--- a/bundles/LayoutsAdminBundle/Resources/es6/components/modal.js
+++ b/bundles/LayoutsAdminBundle/Resources/es6/components/modal.js
@@ -80,7 +80,6 @@ export default class NlModal {
 
     cancel(e) {
         e && e.preventDefault();
-        this.el.dispatchEvent(new Event('cancel'));
         this.close();
     }
 


### PR DESCRIPTION
The `cancel` method would previously dispatch a `cancel` event and call the `close` method. The `close` method would then dispatch another `cancel` event. Thus, when calling the `cancel` method, two `cancel` events would end up dispatched, leading to event handlers being called twice.

This was observed in the "Add new policy" modal dialog, where canceling fires an HTTP request to discard a draft. The first request would discard the draft successfully, but the second would fail because the draft had already been discarded.

The `cancel` method always calls the `close` method and the `close` method always dispatches the event. Therefore, the `cancel` method does not need to dispatch the event itself, instead being able to rely on the `close` method to do it.