### PR TITLE
tweak ajax-paging.js to fix accessibility focus issues

### DIFF
--- a/bundles/LayoutsBundle/Resources/es6/ajax-paging.js
+++ b/bundles/LayoutsBundle/Resources/es6/ajax-paging.js
@@ -69,7 +69,7 @@ class AjaxPaging {
       pager.addEventListener('click', (e) => {
         if (e.target.tagName === 'A') {
           e.preventDefault();
-          this.container?.setAttribute('aria-busy', 'true');
+          this.container.setAttribute('aria-busy', 'true');
           this.getPage(e.target.href);
         }
       });
@@ -111,15 +111,17 @@ class AjaxPaging {
 
     switch (this.pagerData.type) {
       case 'load_more':
-        this.container?.append(...newItems);
-        firstNewItemRef?.setAttribute('tabindex', '0');
-        firstNewItemRef?.focus();
-        firstNewItemRef?.removeAttribute('tabindex');
+        this.container.append(...newItems);
+        if (firstNewItemRef) {
+          firstNewItemRef.setAttribute('tabindex', '0');
+          firstNewItemRef.focus();
+          firstNewItemRef.removeAttribute('tabindex');
+        }
         break;
       default:
-        this.container?.replaceChildren(...newItems);
+        this.container.replaceChildren(...newItems);
     }
-    this.container?.setAttribute('aria-busy', 'false');
+    this.container.setAttribute('aria-busy', 'false');
 
     this.el.dispatchEvent(new CustomEvent('ajax-paging-added', { bubbles: true, cancelable: true, detail: { instance: this } }));
   }

--- a/bundles/LayoutsBundle/Resources/es6/ajax-paging.js
+++ b/bundles/LayoutsBundle/Resources/es6/ajax-paging.js
@@ -69,6 +69,7 @@ class AjaxPaging {
       pager.addEventListener('click', (e) => {
         if (e.target.tagName === 'A') {
           e.preventDefault();
+          this.container?.setAttribute('aria-busy', 'true');
           this.getPage(e.target.href);
         }
       });
@@ -103,13 +104,23 @@ class AjaxPaging {
   }
 
   renderNewPage(html) {
+    const domParser = new DOMParser();
+    const doc = domParser.parseFromString(html, 'text/html');
+    const newItems = doc.body.children;
+    const firstNewItemRef = newItems[0];
+
     switch (this.pagerData.type) {
       case 'load_more':
-        this.container.insertAdjacentHTML('beforeend', html);
+        this.container?.append(...newItems);
+        firstNewItemRef?.setAttribute('tabindex', '0');
+        firstNewItemRef?.focus();
+        firstNewItemRef?.removeAttribute('tabindex');
         break;
       default:
-        this.container.innerHTML = html;
+        this.container?.replaceChildren(...newItems);
     }
+    this.container?.setAttribute('aria-busy', 'false');
+
     this.el.dispatchEvent(new CustomEvent('ajax-paging-added', { bubbles: true, cancelable: true, detail: { instance: this } }));
   }
 


### PR DESCRIPTION
- sets and unsets aria-busy on container now
- uses DOMParser so that element reference can be stored and focused when fetched collection is rendered